### PR TITLE
Fix Sentry Error: WorkerState does not exist

### DIFF
--- a/django_celery_monitor/managers.py
+++ b/django_celery_monitor/managers.py
@@ -52,9 +52,10 @@ class WorkerStateQuerySet(ExtendedQuerySet):
                 hostname=hostname,
                 last_update__gte=interval,
             )
-            if recent_worker_updates.exists():
+            latest_worker_update = recent_worker_updates.first()
+            if latest_worker_update is not None:
                 # if yes, get the latest update and move on
-                obj = recent_worker_updates.get()
+                obj = latest_worker_update
             else:
                 # if no, update the worker state and move on
                 obj, _ = self.select_for_update_or_create(


### PR DESCRIPTION
Related to https://github.com/jezdez/django-celery-monitor/issues/55

Query has a dynamic variable determined by the database, using `Now()` to represent the current timestamp. Since the queries to determine whether a worker update exists and to retrieve the latest one are separate, this can result in the query being executed against a different `interval` expression. This resolves the issue by only executing the query once.