### PR TITLE
Fix post-upgrade bugs

### DIFF
--- a/django_celery_monitor/admin.py
+++ b/django_celery_monitor/admin.py
@@ -10,6 +10,7 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.encoding import force_text
 from django.utils.html import escape
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from celery import current_app
@@ -40,6 +41,7 @@ class MonitorList(main_views.ChangeList):
         self.title = self.model_admin.list_page_title
 
 
+@mark_safe
 @display_field(_('state'), 'state')
 def colored_state(task):
     """Return the task state colored with HTML/CSS according to its level.
@@ -51,6 +53,7 @@ def colored_state(task):
     return '<b><span style="color: {0};">{1}</span></b>'.format(color, state)
 
 
+@mark_safe
 @display_field(_('state'), 'last_heartbeat')
 def node_state(node):
     """Return the worker state colored with HTML/CSS according to its level.
@@ -62,6 +65,7 @@ def node_state(node):
     return '<b><span style="color: {0};">{1}</span></b>'.format(color, state)
 
 
+@mark_safe
 @display_field(_('ETA'), 'eta')
 def eta(task):
     """Return the task ETA as a grey "none" if none is provided."""
@@ -70,6 +74,7 @@ def eta(task):
     return escape(make_aware(task.eta))
 
 
+@mark_safe
 @display_field(_('when'), 'tstamp')
 def tstamp(task):
     """Better timestamp rendering.
@@ -83,6 +88,7 @@ def tstamp(task):
     )
 
 
+@mark_safe
 @display_field(_('name'), 'name')
 def name(task):
     """Return the task name and abbreviates it to maximum of 16 characters."""

--- a/django_celery_monitor/managers.py
+++ b/django_celery_monitor/managers.py
@@ -7,11 +7,7 @@ from celery.events.state import Task
 from celery.utils.time import maybe_timedelta
 from django.db import models, router, transaction
 
-import logging
-
 from .utils import Now
-
-logger = logging.getLogger()
 
 
 class ExtendedQuerySet(models.QuerySet):

--- a/django_celery_monitor/utils.py
+++ b/django_celery_monitor/utils.py
@@ -10,6 +10,8 @@ from django.conf import settings
 from django.db.models import DateTimeField, Func
 from django.utils import timezone
 from django.utils.html import escape
+from django.utils.safestring import mark_safe
+
 
 try:
     from django.db.models.functions import Now
@@ -108,5 +110,5 @@ def fixedwidth(field, name=None, pt=6, width=16, maxlen=64, pretty=False):
         styled = FIXEDWIDTH_STYLE.format(
             escape(val[:255]), pt, escape(shortval),
         )
-        return styled.replace('|br/|', '<br/>')
+        return mark_safe(styled.replace('|br/|', '<br/>'))
     return f


### PR DESCRIPTION
This fixes a couple bugs stemming from incompatibility between the current implementation and Django 2.2.

The first bug is a show-stopping one, due to a change in function signature for `QuerySet._extract_model_params` which resulted in a different result type.

The second bug I noticed when confirming that the first fix worked, which caused the HTML in the Django admin views to render as text rather than HTML, e.g. `<span><b>[task ID]</b></span>` instead of `[task ID]`.